### PR TITLE
Cambios para poder desplegar en Alastria

### DIFF
--- a/contracts/identityManager/AlastriaIdentityIssuer.sol
+++ b/contracts/identityManager/AlastriaIdentityIssuer.sol
@@ -29,8 +29,10 @@ contract AlastriaIdentityIssuer {
     }
 
     constructor () public {
-        // FIXME: This must be an Alastria_ID created from AlastriaIdentityManager.
-        addIdentityIssuer(msg.sender, Eidas.EidasLevel.High);
+	IdentityIssuer storage identityIssuer;
+        identityIssuer.level = Eidas.EidasLevel.High;
+        identityIssuer.active = true;
+	issuers[msg.sender] = identityIssuer;
     }
 
     function addIdentityIssuer(address _identityIssuer, Eidas.EidasLevel _level) public alLeastLow(_level) notIdentityIssuer(_identityIssuer) {

--- a/contracts/identityManager/AlastriaIdentityIssuer.sol
+++ b/contracts/identityManager/AlastriaIdentityIssuer.sol
@@ -29,6 +29,7 @@ contract AlastriaIdentityIssuer {
     }
 
     constructor () public {
+
 	IdentityIssuer storage identityIssuer;
         identityIssuer.level = Eidas.EidasLevel.High;
         identityIssuer.active = true;

--- a/contracts/identityManager/AlastriaIdentityServiceProvider.sol
+++ b/contracts/identityManager/AlastriaIdentityServiceProvider.sol
@@ -19,8 +19,7 @@ contract AlastriaIdentityServiceProvider {
     }
 
     constructor () public {
-        // FIXME: This must be an Alastria_ID created from AlastriaIdentityManager.
-        addIdentityServiceProvider(msg.sender);
+        providers[msg.sender] = true;
     }
 
     function addIdentityServiceProvider(address _identityServiceProvider) public onlyIdentityServiceProvider(msg.sender) notIdentityServiceProvider(_identityServiceProvider) {

--- a/contracts/identityManager/AlastriaIdentityServiceProvider.sol
+++ b/contracts/identityManager/AlastriaIdentityServiceProvider.sol
@@ -19,6 +19,7 @@ contract AlastriaIdentityServiceProvider {
     }
 
     constructor () public {
+
         providers[msg.sender] = true;
     }
 


### PR DESCRIPTION
Los constructores de las clases AlastriaIdentityIssuer y AlastriaIdentityServiceProvider hacen una llamada a funciones del tipo addIdentityServiceProvider(). Estas funciones utilizan unos modificadores que tienen una condición required que fallan en la ejecución del constructor por lo que el despliegue sobre Alastria fallaba.